### PR TITLE
Fixes to run tests

### DIFF
--- a/address_test.go
+++ b/address_test.go
@@ -12,6 +12,7 @@ import (
 	"strings"
 	"testing"
 
+	x9_ltcutil "github.com/X9Developers/ltcutil"
 	"github.com/btcsuite/golangcrypto/ripemd160"
 	"github.com/ltcsuite/ltcd/chaincfg"
 	"github.com/ltcsuite/ltcutil"
@@ -33,7 +34,7 @@ func TestAddresses(t *testing.T) {
 			addr:    "1MirQ9bwyQcGVJPwKUgapu5ouK2E2Ey4gX",
 			encoded: "1MirQ9bwyQcGVJPwKUgapu5ouK2E2Ey4gX",
 			valid:   true,
-			result: ltcutil.TstAddressPubKeyHash(
+			result: x9_ltcutil.TstAddressPubKeyHash(
 				[ripemd160.Size]byte{
 					0xe3, 0x4c, 0xce, 0x70, 0xc8, 0x63, 0x73, 0x27, 0x3e, 0xfc,
 					0xc5, 0x4c, 0xe7, 0xd2, 0xa4, 0x91, 0xbb, 0x4a, 0x0e, 0x84},
@@ -51,7 +52,7 @@ func TestAddresses(t *testing.T) {
 			addr:    "12MzCDwodF9G1e7jfwLXfR164RNtx4BRVG",
 			encoded: "12MzCDwodF9G1e7jfwLXfR164RNtx4BRVG",
 			valid:   true,
-			result: ltcutil.TstAddressPubKeyHash(
+			result: x9_ltcutil.TstAddressPubKeyHash(
 				[ripemd160.Size]byte{
 					0x0e, 0xf0, 0x30, 0x10, 0x7f, 0xd2, 0x6e, 0x0b, 0x6b, 0xf4,
 					0x05, 0x12, 0xbc, 0xa2, 0xce, 0xb1, 0xdd, 0x80, 0xad, 0xaa},
@@ -69,18 +70,18 @@ func TestAddresses(t *testing.T) {
 			addr:    "mrX9vMRYLfVy1BnZbc5gZjuyaqH3ZW2ZHz",
 			encoded: "mrX9vMRYLfVy1BnZbc5gZjuyaqH3ZW2ZHz",
 			valid:   true,
-			result: ltcutil.TstAddressPubKeyHash(
+			result: x9_ltcutil.TstAddressPubKeyHash(
 				[ripemd160.Size]byte{
 					0x78, 0xb3, 0x16, 0xa0, 0x86, 0x47, 0xd5, 0xb7, 0x72, 0x83,
 					0xe5, 0x12, 0xd3, 0x60, 0x3f, 0x1f, 0x1c, 0x8d, 0xe6, 0x8f},
-				chaincfg.TestNet3Params.PubKeyHashAddrID),
+				chaincfg.TestNet4Params.PubKeyHashAddrID),
 			f: func() (ltcutil.Address, error) {
 				pkHash := []byte{
 					0x78, 0xb3, 0x16, 0xa0, 0x86, 0x47, 0xd5, 0xb7, 0x72, 0x83,
 					0xe5, 0x12, 0xd3, 0x60, 0x3f, 0x1f, 0x1c, 0x8d, 0xe6, 0x8f}
-				return ltcutil.NewAddressPubKeyHash(pkHash, &chaincfg.TestNet3Params)
+				return ltcutil.NewAddressPubKeyHash(pkHash, &chaincfg.TestNet4Params)
 			},
-			net: &chaincfg.TestNet3Params,
+			net: &chaincfg.TestNet4Params,
 		},
 
 		// Negative P2PKH tests.
@@ -113,7 +114,7 @@ func TestAddresses(t *testing.T) {
 			addr:    "3QJmV3qfvL9SuYo34YihAf3sRCW3qSinyC",
 			encoded: "3QJmV3qfvL9SuYo34YihAf3sRCW3qSinyC",
 			valid:   true,
-			result: ltcutil.TstAddressScriptHash(
+			result: x9_ltcutil.TstAddressScriptHash(
 				[ripemd160.Size]byte{
 					0xf8, 0x15, 0xb0, 0x36, 0xd9, 0xbb, 0xbc, 0xe5, 0xe9, 0xf2,
 					0xa0, 0x0a, 0xbd, 0x1b, 0xf3, 0xdc, 0x91, 0xe9, 0x55, 0x10},
@@ -153,7 +154,7 @@ func TestAddresses(t *testing.T) {
 			addr:    "3NukJ6fYZJ5Kk8bPjycAnruZkE5Q7UW7i8",
 			encoded: "3NukJ6fYZJ5Kk8bPjycAnruZkE5Q7UW7i8",
 			valid:   true,
-			result: ltcutil.TstAddressScriptHash(
+			result: x9_ltcutil.TstAddressScriptHash(
 				[ripemd160.Size]byte{
 					0xe8, 0xc3, 0x00, 0xc8, 0x79, 0x86, 0xef, 0xa8, 0x4c, 0x37,
 					0xc0, 0x51, 0x99, 0x29, 0x01, 0x9e, 0xf8, 0x6e, 0xb5, 0xb4},
@@ -172,18 +173,18 @@ func TestAddresses(t *testing.T) {
 			addr:    "2NBFNJTktNa7GZusGbDbGKRZTxdK9VVez3n",
 			encoded: "2NBFNJTktNa7GZusGbDbGKRZTxdK9VVez3n",
 			valid:   true,
-			result: ltcutil.TstAddressScriptHash(
+			result: x9_ltcutil.TstAddressScriptHash(
 				[ripemd160.Size]byte{
 					0xc5, 0x79, 0x34, 0x2c, 0x2c, 0x4c, 0x92, 0x20, 0x20, 0x5e,
 					0x2c, 0xdc, 0x28, 0x56, 0x17, 0x04, 0x0c, 0x92, 0x4a, 0x0a},
-				chaincfg.TestNet3Params.ScriptHashAddrID),
+				chaincfg.TestNet4Params.ScriptHashAddrID),
 			f: func() (ltcutil.Address, error) {
 				hash := []byte{
 					0xc5, 0x79, 0x34, 0x2c, 0x2c, 0x4c, 0x92, 0x20, 0x20, 0x5e,
 					0x2c, 0xdc, 0x28, 0x56, 0x17, 0x04, 0x0c, 0x92, 0x4a, 0x0a}
-				return ltcutil.NewAddressScriptHashFromHash(hash, &chaincfg.TestNet3Params)
+				return ltcutil.NewAddressScriptHashFromHash(hash, &chaincfg.TestNet4Params)
 			},
-			net: &chaincfg.TestNet3Params,
+			net: &chaincfg.TestNet4Params,
 		},
 
 		// Negative P2SH tests.
@@ -207,7 +208,7 @@ func TestAddresses(t *testing.T) {
 			addr:    "02192d74d0cb94344c9569c2e77901573d8d7903c3ebec3a957724895dca52c6b4",
 			encoded: "13CG6SJ3yHUXo4Cr2RY4THLLJrNFuG3gUg",
 			valid:   true,
-			result: ltcutil.TstAddressPubKey(
+			result: x9_ltcutil.TstAddressPubKey(
 				[]byte{
 					0x02, 0x19, 0x2d, 0x74, 0xd0, 0xcb, 0x94, 0x34, 0x4c, 0x95,
 					0x69, 0xc2, 0xe7, 0x79, 0x01, 0x57, 0x3d, 0x8d, 0x79, 0x03,
@@ -229,7 +230,7 @@ func TestAddresses(t *testing.T) {
 			addr:    "03b0bd634234abbb1ba1e986e884185c61cf43e001f9137f23c2c409273eb16e65",
 			encoded: "15sHANNUBSh6nDp8XkDPmQcW6n3EFwmvE6",
 			valid:   true,
-			result: ltcutil.TstAddressPubKey(
+			result: x9_ltcutil.TstAddressPubKey(
 				[]byte{
 					0x03, 0xb0, 0xbd, 0x63, 0x42, 0x34, 0xab, 0xbb, 0x1b, 0xa1,
 					0xe9, 0x86, 0xe8, 0x84, 0x18, 0x5c, 0x61, 0xcf, 0x43, 0xe0,
@@ -252,7 +253,7 @@ func TestAddresses(t *testing.T) {
 				"e0eaddfb84ccf9744464f82e160bfa9b8b64f9d4c03f999b8643f656b412a3",
 			encoded: "12cbQLTFMXRnSzktFkuoG3eHoMeFtpTu3S",
 			valid:   true,
-			result: ltcutil.TstAddressPubKey(
+			result: x9_ltcutil.TstAddressPubKey(
 				[]byte{
 					0x04, 0x11, 0xdb, 0x93, 0xe1, 0xdc, 0xdb, 0x8a, 0x01, 0x6b,
 					0x49, 0x84, 0x0f, 0x8c, 0x53, 0xbc, 0x1e, 0xb6, 0x8a, 0x38,
@@ -281,7 +282,7 @@ func TestAddresses(t *testing.T) {
 				"0d45264838c0bd96852662ce6a847b197376830160c6d2eb5e6a4c44d33f453e",
 			encoded: "1Ja5rs7XBZnK88EuLVcFqYGMEbBitzchmX",
 			valid:   true,
-			result: ltcutil.TstAddressPubKey(
+			result: x9_ltcutil.TstAddressPubKey(
 				[]byte{
 					0x06, 0x19, 0x2d, 0x74, 0xd0, 0xcb, 0x94, 0x34, 0x4c, 0x95,
 					0x69, 0xc2, 0xe7, 0x79, 0x01, 0x57, 0x3d, 0x8d, 0x79, 0x03,
@@ -310,7 +311,7 @@ func TestAddresses(t *testing.T) {
 				"37a576782eba668a7ef8bd3b3cfb1edb7117ab65129b8a2e681f3c1e0908ef7b",
 			encoded: "1ExqMmf6yMxcBMzHjbj41wbqYuqoX6uBLG",
 			valid:   true,
-			result: ltcutil.TstAddressPubKey(
+			result: x9_ltcutil.TstAddressPubKey(
 				[]byte{
 					0x07, 0xb0, 0xbd, 0x63, 0x42, 0x34, 0xab, 0xbb, 0x1b, 0xa1,
 					0xe9, 0x86, 0xe8, 0x84, 0x18, 0x5c, 0x61, 0xcf, 0x43, 0xe0,
@@ -338,44 +339,44 @@ func TestAddresses(t *testing.T) {
 			addr:    "02192d74d0cb94344c9569c2e77901573d8d7903c3ebec3a957724895dca52c6b4",
 			encoded: "mhiDPVP2nJunaAgTjzWSHCYfAqxxrxzjmo",
 			valid:   true,
-			result: ltcutil.TstAddressPubKey(
+			result: x9_ltcutil.TstAddressPubKey(
 				[]byte{
 					0x02, 0x19, 0x2d, 0x74, 0xd0, 0xcb, 0x94, 0x34, 0x4c, 0x95,
 					0x69, 0xc2, 0xe7, 0x79, 0x01, 0x57, 0x3d, 0x8d, 0x79, 0x03,
 					0xc3, 0xeb, 0xec, 0x3a, 0x95, 0x77, 0x24, 0x89, 0x5d, 0xca,
 					0x52, 0xc6, 0xb4},
-				ltcutil.PKFCompressed, chaincfg.TestNet3Params.PubKeyHashAddrID),
+				ltcutil.PKFCompressed, chaincfg.TestNet4Params.PubKeyHashAddrID),
 			f: func() (ltcutil.Address, error) {
 				serializedPubKey := []byte{
 					0x02, 0x19, 0x2d, 0x74, 0xd0, 0xcb, 0x94, 0x34, 0x4c, 0x95,
 					0x69, 0xc2, 0xe7, 0x79, 0x01, 0x57, 0x3d, 0x8d, 0x79, 0x03,
 					0xc3, 0xeb, 0xec, 0x3a, 0x95, 0x77, 0x24, 0x89, 0x5d, 0xca,
 					0x52, 0xc6, 0xb4}
-				return ltcutil.NewAddressPubKey(serializedPubKey, &chaincfg.TestNet3Params)
+				return ltcutil.NewAddressPubKey(serializedPubKey, &chaincfg.TestNet4Params)
 			},
-			net: &chaincfg.TestNet3Params,
+			net: &chaincfg.TestNet4Params,
 		},
 		{
 			name:    "testnet p2pk compressed (0x03)",
 			addr:    "03b0bd634234abbb1ba1e986e884185c61cf43e001f9137f23c2c409273eb16e65",
 			encoded: "mkPETRTSzU8MZLHkFKBmbKppxmdw9qT42t",
 			valid:   true,
-			result: ltcutil.TstAddressPubKey(
+			result: x9_ltcutil.TstAddressPubKey(
 				[]byte{
 					0x03, 0xb0, 0xbd, 0x63, 0x42, 0x34, 0xab, 0xbb, 0x1b, 0xa1,
 					0xe9, 0x86, 0xe8, 0x84, 0x18, 0x5c, 0x61, 0xcf, 0x43, 0xe0,
 					0x01, 0xf9, 0x13, 0x7f, 0x23, 0xc2, 0xc4, 0x09, 0x27, 0x3e,
 					0xb1, 0x6e, 0x65},
-				ltcutil.PKFCompressed, chaincfg.TestNet3Params.PubKeyHashAddrID),
+				ltcutil.PKFCompressed, chaincfg.TestNet4Params.PubKeyHashAddrID),
 			f: func() (ltcutil.Address, error) {
 				serializedPubKey := []byte{
 					0x03, 0xb0, 0xbd, 0x63, 0x42, 0x34, 0xab, 0xbb, 0x1b, 0xa1,
 					0xe9, 0x86, 0xe8, 0x84, 0x18, 0x5c, 0x61, 0xcf, 0x43, 0xe0,
 					0x01, 0xf9, 0x13, 0x7f, 0x23, 0xc2, 0xc4, 0x09, 0x27, 0x3e,
 					0xb1, 0x6e, 0x65}
-				return ltcutil.NewAddressPubKey(serializedPubKey, &chaincfg.TestNet3Params)
+				return ltcutil.NewAddressPubKey(serializedPubKey, &chaincfg.TestNet4Params)
 			},
-			net: &chaincfg.TestNet3Params,
+			net: &chaincfg.TestNet4Params,
 		},
 		{
 			name: "testnet p2pk uncompressed (0x04)",
@@ -383,7 +384,7 @@ func TestAddresses(t *testing.T) {
 				"cb2e0eaddfb84ccf9744464f82e160bfa9b8b64f9d4c03f999b8643f656b412a3",
 			encoded: "mh8YhPYEAYs3E7EVyKtB5xrcfMExkkdEMF",
 			valid:   true,
-			result: ltcutil.TstAddressPubKey(
+			result: x9_ltcutil.TstAddressPubKey(
 				[]byte{
 					0x04, 0x11, 0xdb, 0x93, 0xe1, 0xdc, 0xdb, 0x8a, 0x01, 0x6b,
 					0x49, 0x84, 0x0f, 0x8c, 0x53, 0xbc, 0x1e, 0xb6, 0x8a, 0x38,
@@ -392,7 +393,7 @@ func TestAddresses(t *testing.T) {
 					0xf9, 0x74, 0x44, 0x64, 0xf8, 0x2e, 0x16, 0x0b, 0xfa, 0x9b,
 					0x8b, 0x64, 0xf9, 0xd4, 0xc0, 0x3f, 0x99, 0x9b, 0x86, 0x43,
 					0xf6, 0x56, 0xb4, 0x12, 0xa3},
-				ltcutil.PKFUncompressed, chaincfg.TestNet3Params.PubKeyHashAddrID),
+				ltcutil.PKFUncompressed, chaincfg.TestNet4Params.PubKeyHashAddrID),
 			f: func() (ltcutil.Address, error) {
 				serializedPubKey := []byte{
 					0x04, 0x11, 0xdb, 0x93, 0xe1, 0xdc, 0xdb, 0x8a, 0x01, 0x6b,
@@ -402,9 +403,9 @@ func TestAddresses(t *testing.T) {
 					0xf9, 0x74, 0x44, 0x64, 0xf8, 0x2e, 0x16, 0x0b, 0xfa, 0x9b,
 					0x8b, 0x64, 0xf9, 0xd4, 0xc0, 0x3f, 0x99, 0x9b, 0x86, 0x43,
 					0xf6, 0x56, 0xb4, 0x12, 0xa3}
-				return ltcutil.NewAddressPubKey(serializedPubKey, &chaincfg.TestNet3Params)
+				return ltcutil.NewAddressPubKey(serializedPubKey, &chaincfg.TestNet4Params)
 			},
-			net: &chaincfg.TestNet3Params,
+			net: &chaincfg.TestNet4Params,
 		},
 		{
 			name: "testnet p2pk hybrid (0x06)",
@@ -412,7 +413,7 @@ func TestAddresses(t *testing.T) {
 				"40d45264838c0bd96852662ce6a847b197376830160c6d2eb5e6a4c44d33f453e",
 			encoded: "my639vCVzbDZuEiX44adfTUg6anRomZLEP",
 			valid:   true,
-			result: ltcutil.TstAddressPubKey(
+			result: x9_ltcutil.TstAddressPubKey(
 				[]byte{
 					0x06, 0x19, 0x2d, 0x74, 0xd0, 0xcb, 0x94, 0x34, 0x4c, 0x95,
 					0x69, 0xc2, 0xe7, 0x79, 0x01, 0x57, 0x3d, 0x8d, 0x79, 0x03,
@@ -421,7 +422,7 @@ func TestAddresses(t *testing.T) {
 					0x96, 0x85, 0x26, 0x62, 0xce, 0x6a, 0x84, 0x7b, 0x19, 0x73,
 					0x76, 0x83, 0x01, 0x60, 0xc6, 0xd2, 0xeb, 0x5e, 0x6a, 0x4c,
 					0x44, 0xd3, 0x3f, 0x45, 0x3e},
-				ltcutil.PKFHybrid, chaincfg.TestNet3Params.PubKeyHashAddrID),
+				ltcutil.PKFHybrid, chaincfg.TestNet4Params.PubKeyHashAddrID),
 			f: func() (ltcutil.Address, error) {
 				serializedPubKey := []byte{
 					0x06, 0x19, 0x2d, 0x74, 0xd0, 0xcb, 0x94, 0x34, 0x4c, 0x95,
@@ -431,9 +432,9 @@ func TestAddresses(t *testing.T) {
 					0x96, 0x85, 0x26, 0x62, 0xce, 0x6a, 0x84, 0x7b, 0x19, 0x73,
 					0x76, 0x83, 0x01, 0x60, 0xc6, 0xd2, 0xeb, 0x5e, 0x6a, 0x4c,
 					0x44, 0xd3, 0x3f, 0x45, 0x3e}
-				return ltcutil.NewAddressPubKey(serializedPubKey, &chaincfg.TestNet3Params)
+				return ltcutil.NewAddressPubKey(serializedPubKey, &chaincfg.TestNet4Params)
 			},
-			net: &chaincfg.TestNet3Params,
+			net: &chaincfg.TestNet4Params,
 		},
 		{
 			name: "testnet p2pk hybrid (0x07)",
@@ -441,7 +442,7 @@ func TestAddresses(t *testing.T) {
 				"537a576782eba668a7ef8bd3b3cfb1edb7117ab65129b8a2e681f3c1e0908ef7b",
 			encoded: "muUnepk5nPPrxUTuTAhRqrpAQuSWS5fVii",
 			valid:   true,
-			result: ltcutil.TstAddressPubKey(
+			result: x9_ltcutil.TstAddressPubKey(
 				[]byte{
 					0x07, 0xb0, 0xbd, 0x63, 0x42, 0x34, 0xab, 0xbb, 0x1b, 0xa1,
 					0xe9, 0x86, 0xe8, 0x84, 0x18, 0x5c, 0x61, 0xcf, 0x43, 0xe0,
@@ -450,7 +451,7 @@ func TestAddresses(t *testing.T) {
 					0x8a, 0x7e, 0xf8, 0xbd, 0x3b, 0x3c, 0xfb, 0x1e, 0xdb, 0x71,
 					0x17, 0xab, 0x65, 0x12, 0x9b, 0x8a, 0x2e, 0x68, 0x1f, 0x3c,
 					0x1e, 0x09, 0x08, 0xef, 0x7b},
-				ltcutil.PKFHybrid, chaincfg.TestNet3Params.PubKeyHashAddrID),
+				ltcutil.PKFHybrid, chaincfg.TestNet4Params.PubKeyHashAddrID),
 			f: func() (ltcutil.Address, error) {
 				serializedPubKey := []byte{
 					0x07, 0xb0, 0xbd, 0x63, 0x42, 0x34, 0xab, 0xbb, 0x1b, 0xa1,
@@ -460,9 +461,9 @@ func TestAddresses(t *testing.T) {
 					0x8a, 0x7e, 0xf8, 0xbd, 0x3b, 0x3c, 0xfb, 0x1e, 0xdb, 0x71,
 					0x17, 0xab, 0x65, 0x12, 0x9b, 0x8a, 0x2e, 0x68, 0x1f, 0x3c,
 					0x1e, 0x09, 0x08, 0xef, 0x7b}
-				return ltcutil.NewAddressPubKey(serializedPubKey, &chaincfg.TestNet3Params)
+				return ltcutil.NewAddressPubKey(serializedPubKey, &chaincfg.TestNet4Params)
 			},
-			net: &chaincfg.TestNet3Params,
+			net: &chaincfg.TestNet4Params,
 		},
 		// Segwit address tests.
 		{
@@ -470,7 +471,7 @@ func TestAddresses(t *testing.T) {
 			addr:    "BC1QW508D6QEJXTDG4Y5R3ZARVARY0C5XW7KV8F3T4",
 			encoded: "bc1qw508d6qejxtdg4y5r3zarvary0c5xw7kv8f3t4",
 			valid:   true,
-			result: ltcutil.TstAddressWitnessPubKeyHash(
+			result: x9_ltcutil.TstAddressWitnessPubKeyHash(
 				0,
 				[20]byte{
 					0x75, 0x1e, 0x76, 0xe8, 0x19, 0x91, 0x96, 0xd4, 0x54, 0x94,
@@ -489,7 +490,7 @@ func TestAddresses(t *testing.T) {
 			addr:    "bc1qrp33g0q5c5txsp9arysrx4k6zdkfs4nce4xj0gdcccefvpysxf3qccfmv3",
 			encoded: "bc1qrp33g0q5c5txsp9arysrx4k6zdkfs4nce4xj0gdcccefvpysxf3qccfmv3",
 			valid:   true,
-			result: ltcutil.TstAddressWitnessScriptHash(
+			result: x9_ltcutil.TstAddressWitnessScriptHash(
 				0,
 				[32]byte{
 					0x18, 0x63, 0x14, 0x3c, 0x14, 0xc5, 0x16, 0x68,
@@ -512,65 +513,65 @@ func TestAddresses(t *testing.T) {
 			addr:    "tb1qw508d6qejxtdg4y5r3zarvary0c5xw7kxpjzsx",
 			encoded: "tb1qw508d6qejxtdg4y5r3zarvary0c5xw7kxpjzsx",
 			valid:   true,
-			result: ltcutil.TstAddressWitnessPubKeyHash(
+			result: x9_ltcutil.TstAddressWitnessPubKeyHash(
 				0,
 				[20]byte{
 					0x75, 0x1e, 0x76, 0xe8, 0x19, 0x91, 0x96, 0xd4, 0x54, 0x94,
 					0x1c, 0x45, 0xd1, 0xb3, 0xa3, 0x23, 0xf1, 0x43, 0x3b, 0xd6},
-				chaincfg.TestNet3Params.Bech32HRPSegwit),
+				chaincfg.TestNet4Params.Bech32HRPSegwit),
 			f: func() (ltcutil.Address, error) {
 				pkHash := []byte{
 					0x75, 0x1e, 0x76, 0xe8, 0x19, 0x91, 0x96, 0xd4, 0x54, 0x94,
 					0x1c, 0x45, 0xd1, 0xb3, 0xa3, 0x23, 0xf1, 0x43, 0x3b, 0xd6}
-				return ltcutil.NewAddressWitnessPubKeyHash(pkHash, &chaincfg.TestNet3Params)
+				return ltcutil.NewAddressWitnessPubKeyHash(pkHash, &chaincfg.TestNet4Params)
 			},
-			net: &chaincfg.TestNet3Params,
+			net: &chaincfg.TestNet4Params,
 		},
 		{
 			name:    "segwit testnet p2wsh v0",
 			addr:    "tb1qrp33g0q5c5txsp9arysrx4k6zdkfs4nce4xj0gdcccefvpysxf3q0sl5k7",
 			encoded: "tb1qrp33g0q5c5txsp9arysrx4k6zdkfs4nce4xj0gdcccefvpysxf3q0sl5k7",
 			valid:   true,
-			result: ltcutil.TstAddressWitnessScriptHash(
+			result: x9_ltcutil.TstAddressWitnessScriptHash(
 				0,
 				[32]byte{
 					0x18, 0x63, 0x14, 0x3c, 0x14, 0xc5, 0x16, 0x68,
 					0x04, 0xbd, 0x19, 0x20, 0x33, 0x56, 0xda, 0x13,
 					0x6c, 0x98, 0x56, 0x78, 0xcd, 0x4d, 0x27, 0xa1,
 					0xb8, 0xc6, 0x32, 0x96, 0x04, 0x90, 0x32, 0x62},
-				chaincfg.TestNet3Params.Bech32HRPSegwit),
+				chaincfg.TestNet4Params.Bech32HRPSegwit),
 			f: func() (ltcutil.Address, error) {
 				scriptHash := []byte{
 					0x18, 0x63, 0x14, 0x3c, 0x14, 0xc5, 0x16, 0x68,
 					0x04, 0xbd, 0x19, 0x20, 0x33, 0x56, 0xda, 0x13,
 					0x6c, 0x98, 0x56, 0x78, 0xcd, 0x4d, 0x27, 0xa1,
 					0xb8, 0xc6, 0x32, 0x96, 0x04, 0x90, 0x32, 0x62}
-				return ltcutil.NewAddressWitnessScriptHash(scriptHash, &chaincfg.TestNet3Params)
+				return ltcutil.NewAddressWitnessScriptHash(scriptHash, &chaincfg.TestNet4Params)
 			},
-			net: &chaincfg.TestNet3Params,
+			net: &chaincfg.TestNet4Params,
 		},
 		{
 			name:    "segwit testnet p2wsh witness v0",
 			addr:    "tb1qqqqqp399et2xygdj5xreqhjjvcmzhxw4aywxecjdzew6hylgvsesrxh6hy",
 			encoded: "tb1qqqqqp399et2xygdj5xreqhjjvcmzhxw4aywxecjdzew6hylgvsesrxh6hy",
 			valid:   true,
-			result: ltcutil.TstAddressWitnessScriptHash(
+			result: x9_ltcutil.TstAddressWitnessScriptHash(
 				0,
 				[32]byte{
 					0x00, 0x00, 0x00, 0xc4, 0xa5, 0xca, 0xd4, 0x62,
 					0x21, 0xb2, 0xa1, 0x87, 0x90, 0x5e, 0x52, 0x66,
 					0x36, 0x2b, 0x99, 0xd5, 0xe9, 0x1c, 0x6c, 0xe2,
 					0x4d, 0x16, 0x5d, 0xab, 0x93, 0xe8, 0x64, 0x33},
-				chaincfg.TestNet3Params.Bech32HRPSegwit),
+				chaincfg.TestNet4Params.Bech32HRPSegwit),
 			f: func() (ltcutil.Address, error) {
 				scriptHash := []byte{
 					0x00, 0x00, 0x00, 0xc4, 0xa5, 0xca, 0xd4, 0x62,
 					0x21, 0xb2, 0xa1, 0x87, 0x90, 0x5e, 0x52, 0x66,
 					0x36, 0x2b, 0x99, 0xd5, 0xe9, 0x1c, 0x6c, 0xe2,
 					0x4d, 0x16, 0x5d, 0xab, 0x93, 0xe8, 0x64, 0x33}
-				return ltcutil.NewAddressWitnessScriptHash(scriptHash, &chaincfg.TestNet3Params)
+				return ltcutil.NewAddressWitnessScriptHash(scriptHash, &chaincfg.TestNet4Params)
 			},
-			net: &chaincfg.TestNet3Params,
+			net: &chaincfg.TestNet4Params,
 		},
 		// Unsupported witness versions (version 0 only supported at this point)
 		{
@@ -596,7 +597,7 @@ func TestAddresses(t *testing.T) {
 			name:  "segwit invalid hrp",
 			addr:  "tc1qw508d6qejxtdg4y5r3zarvary0c5xw7kg3g4ty",
 			valid: false,
-			net:   &chaincfg.TestNet3Params,
+			net:   &chaincfg.TestNet4Params,
 		},
 		{
 			name:  "segwit invalid checksum",
@@ -632,19 +633,19 @@ func TestAddresses(t *testing.T) {
 			name:  "segwit mixed case",
 			addr:  "tb1qrp33g0q5c5txsp9arysrx4k6zdkfs4nce4xj0gdcccefvpysxf3q0sL5k7",
 			valid: false,
-			net:   &chaincfg.TestNet3Params,
+			net:   &chaincfg.TestNet4Params,
 		},
 		{
 			name:  "segwit zero padding of more than 4 bits",
 			addr:  "tb1pw508d6qejxtdg4y5r3zarqfsj6c3",
 			valid: false,
-			net:   &chaincfg.TestNet3Params,
+			net:   &chaincfg.TestNet4Params,
 		},
 		{
 			name:  "segwit non-zero padding in 8-to-5 conversion",
 			addr:  "tb1qrp33g0q5c5txsp9arysrx4k6zdkfs4nce4xj0gdcccefvpysxf3pjxtptv",
 			valid: false,
-			net:   &chaincfg.TestNet3Params,
+			net:   &chaincfg.TestNet4Params,
 		},
 	}
 
@@ -688,19 +689,19 @@ func TestAddresses(t *testing.T) {
 			var saddr []byte
 			switch d := decoded.(type) {
 			case *ltcutil.AddressPubKeyHash:
-				saddr = ltcutil.TstAddressSAddr(encoded)
+				saddr = x9_ltcutil.TstAddressSAddr(encoded)
 
 			case *ltcutil.AddressScriptHash:
-				saddr = ltcutil.TstAddressSAddr(encoded)
+				saddr = x9_ltcutil.TstAddressSAddr(encoded)
 
 			case *ltcutil.AddressPubKey:
 				// Ignore the error here since the script
 				// address is checked below.
 				saddr, _ = hex.DecodeString(d.String())
 			case *ltcutil.AddressWitnessPubKeyHash:
-				saddr = ltcutil.TstAddressSegwitSAddr(encoded)
+				saddr = x9_ltcutil.TstAddressSegwitSAddr(encoded)
 			case *ltcutil.AddressWitnessScriptHash:
-				saddr = ltcutil.TstAddressSegwitSAddr(encoded)
+				saddr = x9_ltcutil.TstAddressSegwitSAddr(encoded)
 			}
 
 			// Check script address, as well as the Hash160 method for P2PKH and

--- a/address_test.go
+++ b/address_test.go
@@ -12,9 +12,9 @@ import (
 	"strings"
 	"testing"
 
-	"github.com/X9Developers/ltcutil"
 	"github.com/btcsuite/golangcrypto/ripemd160"
 	"github.com/ltcsuite/ltcd/chaincfg"
+	"github.com/ltcsuite/ltcutil"
 )
 
 func TestAddresses(t *testing.T) {

--- a/address_test.go
+++ b/address_test.go
@@ -12,10 +12,9 @@ import (
 	"strings"
 	"testing"
 
-	x9_ltcutil "github.com/X9Developers/ltcutil"
+	"github.com/X9Developers/ltcutil"
 	"github.com/btcsuite/golangcrypto/ripemd160"
 	"github.com/ltcsuite/ltcd/chaincfg"
-	"github.com/ltcsuite/ltcutil"
 )
 
 func TestAddresses(t *testing.T) {
@@ -34,7 +33,7 @@ func TestAddresses(t *testing.T) {
 			addr:    "1MirQ9bwyQcGVJPwKUgapu5ouK2E2Ey4gX",
 			encoded: "1MirQ9bwyQcGVJPwKUgapu5ouK2E2Ey4gX",
 			valid:   true,
-			result: x9_ltcutil.TstAddressPubKeyHash(
+			result: ltcutil.TstAddressPubKeyHash(
 				[ripemd160.Size]byte{
 					0xe3, 0x4c, 0xce, 0x70, 0xc8, 0x63, 0x73, 0x27, 0x3e, 0xfc,
 					0xc5, 0x4c, 0xe7, 0xd2, 0xa4, 0x91, 0xbb, 0x4a, 0x0e, 0x84},
@@ -52,7 +51,7 @@ func TestAddresses(t *testing.T) {
 			addr:    "12MzCDwodF9G1e7jfwLXfR164RNtx4BRVG",
 			encoded: "12MzCDwodF9G1e7jfwLXfR164RNtx4BRVG",
 			valid:   true,
-			result: x9_ltcutil.TstAddressPubKeyHash(
+			result: ltcutil.TstAddressPubKeyHash(
 				[ripemd160.Size]byte{
 					0x0e, 0xf0, 0x30, 0x10, 0x7f, 0xd2, 0x6e, 0x0b, 0x6b, 0xf4,
 					0x05, 0x12, 0xbc, 0xa2, 0xce, 0xb1, 0xdd, 0x80, 0xad, 0xaa},
@@ -70,7 +69,7 @@ func TestAddresses(t *testing.T) {
 			addr:    "mrX9vMRYLfVy1BnZbc5gZjuyaqH3ZW2ZHz",
 			encoded: "mrX9vMRYLfVy1BnZbc5gZjuyaqH3ZW2ZHz",
 			valid:   true,
-			result: x9_ltcutil.TstAddressPubKeyHash(
+			result: ltcutil.TstAddressPubKeyHash(
 				[ripemd160.Size]byte{
 					0x78, 0xb3, 0x16, 0xa0, 0x86, 0x47, 0xd5, 0xb7, 0x72, 0x83,
 					0xe5, 0x12, 0xd3, 0x60, 0x3f, 0x1f, 0x1c, 0x8d, 0xe6, 0x8f},
@@ -114,7 +113,7 @@ func TestAddresses(t *testing.T) {
 			addr:    "3QJmV3qfvL9SuYo34YihAf3sRCW3qSinyC",
 			encoded: "3QJmV3qfvL9SuYo34YihAf3sRCW3qSinyC",
 			valid:   true,
-			result: x9_ltcutil.TstAddressScriptHash(
+			result: ltcutil.TstAddressScriptHash(
 				[ripemd160.Size]byte{
 					0xf8, 0x15, 0xb0, 0x36, 0xd9, 0xbb, 0xbc, 0xe5, 0xe9, 0xf2,
 					0xa0, 0x0a, 0xbd, 0x1b, 0xf3, 0xdc, 0x91, 0xe9, 0x55, 0x10},
@@ -154,7 +153,7 @@ func TestAddresses(t *testing.T) {
 			addr:    "3NukJ6fYZJ5Kk8bPjycAnruZkE5Q7UW7i8",
 			encoded: "3NukJ6fYZJ5Kk8bPjycAnruZkE5Q7UW7i8",
 			valid:   true,
-			result: x9_ltcutil.TstAddressScriptHash(
+			result: ltcutil.TstAddressScriptHash(
 				[ripemd160.Size]byte{
 					0xe8, 0xc3, 0x00, 0xc8, 0x79, 0x86, 0xef, 0xa8, 0x4c, 0x37,
 					0xc0, 0x51, 0x99, 0x29, 0x01, 0x9e, 0xf8, 0x6e, 0xb5, 0xb4},
@@ -173,7 +172,7 @@ func TestAddresses(t *testing.T) {
 			addr:    "2NBFNJTktNa7GZusGbDbGKRZTxdK9VVez3n",
 			encoded: "2NBFNJTktNa7GZusGbDbGKRZTxdK9VVez3n",
 			valid:   true,
-			result: x9_ltcutil.TstAddressScriptHash(
+			result: ltcutil.TstAddressScriptHash(
 				[ripemd160.Size]byte{
 					0xc5, 0x79, 0x34, 0x2c, 0x2c, 0x4c, 0x92, 0x20, 0x20, 0x5e,
 					0x2c, 0xdc, 0x28, 0x56, 0x17, 0x04, 0x0c, 0x92, 0x4a, 0x0a},
@@ -208,7 +207,7 @@ func TestAddresses(t *testing.T) {
 			addr:    "02192d74d0cb94344c9569c2e77901573d8d7903c3ebec3a957724895dca52c6b4",
 			encoded: "13CG6SJ3yHUXo4Cr2RY4THLLJrNFuG3gUg",
 			valid:   true,
-			result: x9_ltcutil.TstAddressPubKey(
+			result: ltcutil.TstAddressPubKey(
 				[]byte{
 					0x02, 0x19, 0x2d, 0x74, 0xd0, 0xcb, 0x94, 0x34, 0x4c, 0x95,
 					0x69, 0xc2, 0xe7, 0x79, 0x01, 0x57, 0x3d, 0x8d, 0x79, 0x03,
@@ -230,7 +229,7 @@ func TestAddresses(t *testing.T) {
 			addr:    "03b0bd634234abbb1ba1e986e884185c61cf43e001f9137f23c2c409273eb16e65",
 			encoded: "15sHANNUBSh6nDp8XkDPmQcW6n3EFwmvE6",
 			valid:   true,
-			result: x9_ltcutil.TstAddressPubKey(
+			result: ltcutil.TstAddressPubKey(
 				[]byte{
 					0x03, 0xb0, 0xbd, 0x63, 0x42, 0x34, 0xab, 0xbb, 0x1b, 0xa1,
 					0xe9, 0x86, 0xe8, 0x84, 0x18, 0x5c, 0x61, 0xcf, 0x43, 0xe0,
@@ -253,7 +252,7 @@ func TestAddresses(t *testing.T) {
 				"e0eaddfb84ccf9744464f82e160bfa9b8b64f9d4c03f999b8643f656b412a3",
 			encoded: "12cbQLTFMXRnSzktFkuoG3eHoMeFtpTu3S",
 			valid:   true,
-			result: x9_ltcutil.TstAddressPubKey(
+			result: ltcutil.TstAddressPubKey(
 				[]byte{
 					0x04, 0x11, 0xdb, 0x93, 0xe1, 0xdc, 0xdb, 0x8a, 0x01, 0x6b,
 					0x49, 0x84, 0x0f, 0x8c, 0x53, 0xbc, 0x1e, 0xb6, 0x8a, 0x38,
@@ -282,7 +281,7 @@ func TestAddresses(t *testing.T) {
 				"0d45264838c0bd96852662ce6a847b197376830160c6d2eb5e6a4c44d33f453e",
 			encoded: "1Ja5rs7XBZnK88EuLVcFqYGMEbBitzchmX",
 			valid:   true,
-			result: x9_ltcutil.TstAddressPubKey(
+			result: ltcutil.TstAddressPubKey(
 				[]byte{
 					0x06, 0x19, 0x2d, 0x74, 0xd0, 0xcb, 0x94, 0x34, 0x4c, 0x95,
 					0x69, 0xc2, 0xe7, 0x79, 0x01, 0x57, 0x3d, 0x8d, 0x79, 0x03,
@@ -311,7 +310,7 @@ func TestAddresses(t *testing.T) {
 				"37a576782eba668a7ef8bd3b3cfb1edb7117ab65129b8a2e681f3c1e0908ef7b",
 			encoded: "1ExqMmf6yMxcBMzHjbj41wbqYuqoX6uBLG",
 			valid:   true,
-			result: x9_ltcutil.TstAddressPubKey(
+			result: ltcutil.TstAddressPubKey(
 				[]byte{
 					0x07, 0xb0, 0xbd, 0x63, 0x42, 0x34, 0xab, 0xbb, 0x1b, 0xa1,
 					0xe9, 0x86, 0xe8, 0x84, 0x18, 0x5c, 0x61, 0xcf, 0x43, 0xe0,
@@ -339,7 +338,7 @@ func TestAddresses(t *testing.T) {
 			addr:    "02192d74d0cb94344c9569c2e77901573d8d7903c3ebec3a957724895dca52c6b4",
 			encoded: "mhiDPVP2nJunaAgTjzWSHCYfAqxxrxzjmo",
 			valid:   true,
-			result: x9_ltcutil.TstAddressPubKey(
+			result: ltcutil.TstAddressPubKey(
 				[]byte{
 					0x02, 0x19, 0x2d, 0x74, 0xd0, 0xcb, 0x94, 0x34, 0x4c, 0x95,
 					0x69, 0xc2, 0xe7, 0x79, 0x01, 0x57, 0x3d, 0x8d, 0x79, 0x03,
@@ -361,7 +360,7 @@ func TestAddresses(t *testing.T) {
 			addr:    "03b0bd634234abbb1ba1e986e884185c61cf43e001f9137f23c2c409273eb16e65",
 			encoded: "mkPETRTSzU8MZLHkFKBmbKppxmdw9qT42t",
 			valid:   true,
-			result: x9_ltcutil.TstAddressPubKey(
+			result: ltcutil.TstAddressPubKey(
 				[]byte{
 					0x03, 0xb0, 0xbd, 0x63, 0x42, 0x34, 0xab, 0xbb, 0x1b, 0xa1,
 					0xe9, 0x86, 0xe8, 0x84, 0x18, 0x5c, 0x61, 0xcf, 0x43, 0xe0,
@@ -384,7 +383,7 @@ func TestAddresses(t *testing.T) {
 				"cb2e0eaddfb84ccf9744464f82e160bfa9b8b64f9d4c03f999b8643f656b412a3",
 			encoded: "mh8YhPYEAYs3E7EVyKtB5xrcfMExkkdEMF",
 			valid:   true,
-			result: x9_ltcutil.TstAddressPubKey(
+			result: ltcutil.TstAddressPubKey(
 				[]byte{
 					0x04, 0x11, 0xdb, 0x93, 0xe1, 0xdc, 0xdb, 0x8a, 0x01, 0x6b,
 					0x49, 0x84, 0x0f, 0x8c, 0x53, 0xbc, 0x1e, 0xb6, 0x8a, 0x38,
@@ -413,7 +412,7 @@ func TestAddresses(t *testing.T) {
 				"40d45264838c0bd96852662ce6a847b197376830160c6d2eb5e6a4c44d33f453e",
 			encoded: "my639vCVzbDZuEiX44adfTUg6anRomZLEP",
 			valid:   true,
-			result: x9_ltcutil.TstAddressPubKey(
+			result: ltcutil.TstAddressPubKey(
 				[]byte{
 					0x06, 0x19, 0x2d, 0x74, 0xd0, 0xcb, 0x94, 0x34, 0x4c, 0x95,
 					0x69, 0xc2, 0xe7, 0x79, 0x01, 0x57, 0x3d, 0x8d, 0x79, 0x03,
@@ -442,7 +441,7 @@ func TestAddresses(t *testing.T) {
 				"537a576782eba668a7ef8bd3b3cfb1edb7117ab65129b8a2e681f3c1e0908ef7b",
 			encoded: "muUnepk5nPPrxUTuTAhRqrpAQuSWS5fVii",
 			valid:   true,
-			result: x9_ltcutil.TstAddressPubKey(
+			result: ltcutil.TstAddressPubKey(
 				[]byte{
 					0x07, 0xb0, 0xbd, 0x63, 0x42, 0x34, 0xab, 0xbb, 0x1b, 0xa1,
 					0xe9, 0x86, 0xe8, 0x84, 0x18, 0x5c, 0x61, 0xcf, 0x43, 0xe0,
@@ -471,7 +470,7 @@ func TestAddresses(t *testing.T) {
 			addr:    "BC1QW508D6QEJXTDG4Y5R3ZARVARY0C5XW7KV8F3T4",
 			encoded: "bc1qw508d6qejxtdg4y5r3zarvary0c5xw7kv8f3t4",
 			valid:   true,
-			result: x9_ltcutil.TstAddressWitnessPubKeyHash(
+			result: ltcutil.TstAddressWitnessPubKeyHash(
 				0,
 				[20]byte{
 					0x75, 0x1e, 0x76, 0xe8, 0x19, 0x91, 0x96, 0xd4, 0x54, 0x94,
@@ -490,7 +489,7 @@ func TestAddresses(t *testing.T) {
 			addr:    "bc1qrp33g0q5c5txsp9arysrx4k6zdkfs4nce4xj0gdcccefvpysxf3qccfmv3",
 			encoded: "bc1qrp33g0q5c5txsp9arysrx4k6zdkfs4nce4xj0gdcccefvpysxf3qccfmv3",
 			valid:   true,
-			result: x9_ltcutil.TstAddressWitnessScriptHash(
+			result: ltcutil.TstAddressWitnessScriptHash(
 				0,
 				[32]byte{
 					0x18, 0x63, 0x14, 0x3c, 0x14, 0xc5, 0x16, 0x68,
@@ -513,7 +512,7 @@ func TestAddresses(t *testing.T) {
 			addr:    "tb1qw508d6qejxtdg4y5r3zarvary0c5xw7kxpjzsx",
 			encoded: "tb1qw508d6qejxtdg4y5r3zarvary0c5xw7kxpjzsx",
 			valid:   true,
-			result: x9_ltcutil.TstAddressWitnessPubKeyHash(
+			result: ltcutil.TstAddressWitnessPubKeyHash(
 				0,
 				[20]byte{
 					0x75, 0x1e, 0x76, 0xe8, 0x19, 0x91, 0x96, 0xd4, 0x54, 0x94,
@@ -532,7 +531,7 @@ func TestAddresses(t *testing.T) {
 			addr:    "tb1qrp33g0q5c5txsp9arysrx4k6zdkfs4nce4xj0gdcccefvpysxf3q0sl5k7",
 			encoded: "tb1qrp33g0q5c5txsp9arysrx4k6zdkfs4nce4xj0gdcccefvpysxf3q0sl5k7",
 			valid:   true,
-			result: x9_ltcutil.TstAddressWitnessScriptHash(
+			result: ltcutil.TstAddressWitnessScriptHash(
 				0,
 				[32]byte{
 					0x18, 0x63, 0x14, 0x3c, 0x14, 0xc5, 0x16, 0x68,
@@ -555,7 +554,7 @@ func TestAddresses(t *testing.T) {
 			addr:    "tb1qqqqqp399et2xygdj5xreqhjjvcmzhxw4aywxecjdzew6hylgvsesrxh6hy",
 			encoded: "tb1qqqqqp399et2xygdj5xreqhjjvcmzhxw4aywxecjdzew6hylgvsesrxh6hy",
 			valid:   true,
-			result: x9_ltcutil.TstAddressWitnessScriptHash(
+			result: ltcutil.TstAddressWitnessScriptHash(
 				0,
 				[32]byte{
 					0x00, 0x00, 0x00, 0xc4, 0xa5, 0xca, 0xd4, 0x62,
@@ -689,19 +688,19 @@ func TestAddresses(t *testing.T) {
 			var saddr []byte
 			switch d := decoded.(type) {
 			case *ltcutil.AddressPubKeyHash:
-				saddr = x9_ltcutil.TstAddressSAddr(encoded)
+				saddr = ltcutil.TstAddressSAddr(encoded)
 
 			case *ltcutil.AddressScriptHash:
-				saddr = x9_ltcutil.TstAddressSAddr(encoded)
+				saddr = ltcutil.TstAddressSAddr(encoded)
 
 			case *ltcutil.AddressPubKey:
 				// Ignore the error here since the script
 				// address is checked below.
 				saddr, _ = hex.DecodeString(d.String())
 			case *ltcutil.AddressWitnessPubKeyHash:
-				saddr = x9_ltcutil.TstAddressSegwitSAddr(encoded)
+				saddr = ltcutil.TstAddressSegwitSAddr(encoded)
 			case *ltcutil.AddressWitnessScriptHash:
-				saddr = x9_ltcutil.TstAddressSegwitSAddr(encoded)
+				saddr = ltcutil.TstAddressSegwitSAddr(encoded)
 			}
 
 			// Check script address, as well as the Hash160 method for P2PKH and

--- a/appdata_test.go
+++ b/appdata_test.go
@@ -12,7 +12,7 @@ import (
 	"testing"
 	"unicode"
 
-	"github.com/X9Developers/ltcutil"
+	"github.com/ltcsuite/ltcutil"
 )
 
 // TestAppDataDir tests the API for AppDataDir to ensure it gives expected

--- a/appdata_test.go
+++ b/appdata_test.go
@@ -12,7 +12,7 @@ import (
 	"testing"
 	"unicode"
 
-	"github.com/ltcsuite/ltcutil"
+	"github.com/X9Developers/ltcutil"
 )
 
 // TestAppDataDir tests the API for AppDataDir to ensure it gives expected

--- a/block_test.go
+++ b/block_test.go
@@ -11,10 +11,10 @@ import (
 	"testing"
 	"time"
 
-	"github.com/X9Developers/ltcutil"
 	"github.com/davecgh/go-spew/spew"
 	"github.com/ltcsuite/ltcd/chaincfg/chainhash"
 	"github.com/ltcsuite/ltcd/wire"
+	"github.com/ltcsuite/ltcutil"
 )
 
 // TestBlock tests the API for Block.

--- a/block_test.go
+++ b/block_test.go
@@ -11,10 +11,10 @@ import (
 	"testing"
 	"time"
 
+	"github.com/davecgh/go-spew/spew"
 	"github.com/ltcsuite/ltcd/chaincfg/chainhash"
 	"github.com/ltcsuite/ltcd/wire"
 	"github.com/ltcsuite/ltcutil"
-	"github.com/davecgh/go-spew/spew"
 )
 
 // TestBlock tests the API for Block.
@@ -286,16 +286,6 @@ func TestBlockErrors(t *testing.T) {
 	if _, ok := err.(ltcutil.OutOfRangeError); !ok {
 		t.Errorf("Tx: wrong error - got: %v <%T>, "+
 			"want: <%T>", err, err, ltcutil.OutOfRangeError(""))
-	}
-
-	// Ensure TxLoc returns expected error with short byte buffer.
-	// This makes use of the test package only function, SetBlockBytes, to
-	// inject a short byte buffer.
-	b.SetBlockBytes(shortBytes)
-	_, err = b.TxLoc()
-	if err != io.EOF {
-		t.Errorf("TxLoc: did not get expected error - "+
-			"got %v, want %v", err, io.EOF)
 	}
 }
 

--- a/block_test.go
+++ b/block_test.go
@@ -11,10 +11,10 @@ import (
 	"testing"
 	"time"
 
+	"github.com/X9Developers/ltcutil"
 	"github.com/davecgh/go-spew/spew"
 	"github.com/ltcsuite/ltcd/chaincfg/chainhash"
 	"github.com/ltcsuite/ltcd/wire"
-	"github.com/ltcsuite/ltcutil"
 )
 
 // TestBlock tests the API for Block.
@@ -286,6 +286,16 @@ func TestBlockErrors(t *testing.T) {
 	if _, ok := err.(ltcutil.OutOfRangeError); !ok {
 		t.Errorf("Tx: wrong error - got: %v <%T>, "+
 			"want: <%T>", err, err, ltcutil.OutOfRangeError(""))
+	}
+
+	// Ensure TxLoc returns expected error with short byte buffer.
+	// This makes use of the test package only function, SetBlockBytes, to
+	// inject a short byte buffer.
+	b.SetBlockBytes(shortBytes)
+	_, err = b.TxLoc()
+	if err != io.EOF {
+		t.Errorf("TxLoc: did not get expected error - "+
+			"got %v, want %v", err, io.EOF)
 	}
 }
 

--- a/bloom/filter.go
+++ b/bloom/filter.go
@@ -113,7 +113,7 @@ func (bf *Filter) Unload() {
 }
 
 // hash returns the bit offset in the bloom filter which corresponds to the
-// passed data for the given indepedent hash function number.
+// passed data for the given independent hash function number.
 func (bf *Filter) hash(hashNum uint32, data []byte) uint32 {
 	// litecoind: 0xfba4c795 chosen as it guarantees a reasonable bit
 	// difference between hashNum values.

--- a/bloom/filter_test.go
+++ b/bloom/filter_test.go
@@ -83,7 +83,7 @@ func TestFilterInsert(t *testing.T) {
 	}
 
 	got := bytes.NewBuffer(nil)
-	err = f.MsgFilterLoad().BtcEncode(got, wire.ProtocolVersion)
+	err = f.MsgFilterLoad().BtcEncode(got, wire.ProtocolVersion, wire.LatestEncoding)
 	if err != nil {
 		t.Errorf("TestFilterInsert BtcDecode failed: %v\n", err)
 		return
@@ -143,7 +143,7 @@ func TestFilterFPRange(t *testing.T) {
 		f := test.filter
 		f.AddHash(hash)
 		got := bytes.NewBuffer(nil)
-		err = f.MsgFilterLoad().BtcEncode(got, wire.ProtocolVersion)
+		err = f.MsgFilterLoad().BtcEncode(got, wire.ProtocolVersion, wire.LatestEncoding)
 		if err != nil {
 			t.Errorf("BtcDecode unexpected error: %v\n", err)
 			continue
@@ -196,7 +196,7 @@ func TestFilterInsertWithTweak(t *testing.T) {
 		return
 	}
 	got := bytes.NewBuffer(nil)
-	err = f.MsgFilterLoad().BtcEncode(got, wire.ProtocolVersion)
+	err = f.MsgFilterLoad().BtcEncode(got, wire.ProtocolVersion, wire.LatestEncoding)
 	if err != nil {
 		t.Errorf("TestFilterInsertWithTweak BtcDecode failed: %v\n", err)
 		return
@@ -230,7 +230,7 @@ func TestFilterInsertKey(t *testing.T) {
 		return
 	}
 	got := bytes.NewBuffer(nil)
-	err = f.MsgFilterLoad().BtcEncode(got, wire.ProtocolVersion)
+	err = f.MsgFilterLoad().BtcEncode(got, wire.ProtocolVersion, wire.LatestEncoding)
 	if err != nil {
 		t.Errorf("TestFilterInsertWithTweak BtcDecode failed: %v\n", err)
 		return

--- a/bloom/merkleblock_test.go
+++ b/bloom/merkleblock_test.go
@@ -60,7 +60,7 @@ func TestMerkleBlock3(t *testing.T) {
 	}
 
 	got := bytes.NewBuffer(nil)
-	err = mBlock.BtcEncode(got, wire.ProtocolVersion)
+	err = mBlock.BtcEncode(got, wire.ProtocolVersion, wire.LatestEncoding)
 	if err != nil {
 		t.Errorf("TestMerkleBlock3 BtcEncode failed: %v", err)
 		return

--- a/hdkeychain/extendedkey_test.go
+++ b/hdkeychain/extendedkey_test.go
@@ -161,7 +161,7 @@ func TestBIP0032Vectors(t *testing.T) {
 			path:     []uint32{},
 			wantPub:  "tpubD6NzVbkrYhZ4XgiXtGrdW5XDAPFCL9h7we1vwNCpn8tGbBcgfVYjXyhWo4E1xkh56hjod1RhGjxbaTLV3X4FyWuejifB9jusQ46QzG87VKp",
 			wantPriv: "tprv8ZgxMBicQKsPeDgjzdC36fs6bMjGApWDNLR9erAXMs5skhMv36j9MV5ecvfavji5khqjWaWSFhN3YcCUUdiKH6isR4Pwy3U5y5egddBr16m",
-			net:      &chaincfg.TestNet3Params,
+			net:      &chaincfg.TestNet4Params,
 		},
 		{
 			name:     "test vector 1 chain m/0H - testnet",
@@ -169,7 +169,7 @@ func TestBIP0032Vectors(t *testing.T) {
 			path:     []uint32{hkStart},
 			wantPub:  "tpubD8eQVK4Kdxg3gHrF62jGP7dKVCoYiEB8dFSpuTawkL5YxTus5j5pf83vaKnii4bc6v2NVEy81P2gYrJczYne3QNNwMTS53p5uzDyHvnw2jm",
 			wantPriv: "tprv8bxNLu25VazNnppTCP4fyhyCvBHcYtzE3wr3cwYeL4HA7yf6TLGEUdS4QC1vLT63TkjRssqJe4CvGNEC8DzW5AoPUw56D1Ayg6HY4oy8QZ9",
-			net:      &chaincfg.TestNet3Params,
+			net:      &chaincfg.TestNet4Params,
 		},
 		{
 			name:     "test vector 1 chain m/0H/1 - testnet",
@@ -177,7 +177,7 @@ func TestBIP0032Vectors(t *testing.T) {
 			path:     []uint32{hkStart, 1},
 			wantPub:  "tpubDApXh6cD2fZ7WjtgpHd8yrWyYaneiFuRZa7fVjMkgxsmC1QzoXW8cgx9zQFJ81Jx4deRGfRE7yXA9A3STsxXj4CKEZJHYgpMYikkas9DBTP",
 			wantPriv: "tprv8e8VYgZxtHsSdGrtvdxYaSrryZGiYviWzGWtDDKTGh5NMXAEB8gYSCLHpFCywNs5uqV7ghRjimALQJkRFZnUrLHpzi2pGkwqLtbubgWuQ8q",
-			net:      &chaincfg.TestNet3Params,
+			net:      &chaincfg.TestNet4Params,
 		},
 		{
 			name:     "test vector 1 chain m/0H/1/2H - testnet",
@@ -185,7 +185,7 @@ func TestBIP0032Vectors(t *testing.T) {
 			path:     []uint32{hkStart, 1, hkStart + 2},
 			wantPub:  "tpubDDRojdS4jYQXNugn4t2WLrZ7mjfAyoVQu7MLk4eurqFCbrc7cHLZX8W5YRS8ZskGR9k9t3PqVv68bVBjAyW4nWM9pTGRddt3GQftg6MVQsm",
 			wantPriv: "tprv8gjmbDPpbAirVSezBEMuwSu1Ci9EpUJWKokZTYccSZSomNMLytWyLdtDNHRbucNaRJWWHANf9AzEdWVAqahfyRjVMKbNRhBmxAM8EJr7R15",
-			net:      &chaincfg.TestNet3Params,
+			net:      &chaincfg.TestNet4Params,
 		},
 		{
 			name:     "test vector 1 chain m/0H/1/2H/2 - testnet",
@@ -193,7 +193,7 @@ func TestBIP0032Vectors(t *testing.T) {
 			path:     []uint32{hkStart, 1, hkStart + 2, 2},
 			wantPub:  "tpubDFfCa4Z1v25WTPAVm9EbEMiRrYwucPocLbEe12BPBGooxxEUg42vihy1DkRWyftztTsL23snYezF9uXjGGwGW6pQjEpcTpmsH6ajpf4CVPn",
 			wantPriv: "tprv8iyAReWmmePqZv8hsVZzpx4KHXRyT4chmHdriW95m11R8Tyi3fDLYDM93bq4NGn1V6eCu5cE3zSQ6hPd31F2ApKXkZgTyn1V78pHjkq1V2v",
-			net:      &chaincfg.TestNet3Params,
+			net:      &chaincfg.TestNet4Params,
 		},
 		{
 			name:     "test vector 1 chain m/0H/1/2H/2/1000000000 - testnet",
@@ -201,7 +201,7 @@ func TestBIP0032Vectors(t *testing.T) {
 			path:     []uint32{hkStart, 1, hkStart + 2, 2, 1000000000},
 			wantPub:  "tpubDHNy3kAG39ThyiwwsgoKY4iRenXDRtce8qdCFJZXPMCJg5dsCUHayp84raLTpvyiNA9sXPob5rgqkKvkN8S7MMyXbnEhGJMW64Cf4vFAoaF",
 			wantPriv: "tprv8kgvuL81tmn36Fv9z38j8f4K5m1HGZRjZY2QxnXDy5PuqbP6a5TzoKWCgTcGHBu66W3TgSbAu2yX6sPza5FkHmy564Sh6gmCPUNeUt4yj2x",
-			net:      &chaincfg.TestNet3Params,
+			net:      &chaincfg.TestNet4Params,
 		},
 	}
 
@@ -232,7 +232,7 @@ tests:
 		}
 
 		if extKey.Depth() != uint8(len(test.path)) {
-			t.Errorf("Depth of key %d should match fixture path")
+			t.Errorf("Depth of key %d should match fixture path", extKey.Depth())
 			continue
 		}
 
@@ -573,7 +573,7 @@ func TestExtendedKeyAPI(t *testing.T) {
 			parentFP:  0,
 			privKey:   "e8f32e723decf4051aefac8e2c93c9c5b214313817cdb01a1494b917c8436b35",
 			pubKey:    "0339a36013301597daef41fbe593a02cc513d0b55527ec2df1050e2e8ff49c85c2",
-			address:   "15mKKb2eos1hWa6tisdPwwDC1a5J1y9nma",
+			address:   "LPzGaoLUtXFkmNo3u1chDxGxDnSaBQTTxm",
 		},
 		{
 			name:       "test vector 1 chain m/0H/1/2H public",
@@ -582,7 +582,7 @@ func TestExtendedKeyAPI(t *testing.T) {
 			parentFP:   3203769081,
 			privKeyErr: ErrNotPrivExtKey,
 			pubKey:     "0357bfe1e341d01c69fe5654309956cbea516822fba8a601743a012a7896ee8dc2",
-			address:    "1NjxqbA9aZWnh17q1UW3rB4EPu79wDXj7x",
+			address:    "Lgxv6oTyfDkqwoozBcVM8C7zc7US8o88Rk",
 		},
 	}
 
@@ -958,7 +958,7 @@ func TestZero(t *testing.T) {
 			return false
 		}
 
-		wantAddr := "1HT7xU2Ngenf7D4yocz2SAcnNLW7rK8d4E"
+		wantAddr := "Lbg5DgLCmK2iN1m8ykyKiBgYaYsQ3S2BCr"
 		addr, err := key.Address(&chaincfg.MainNetParams)
 		if err != nil {
 			t.Errorf("Addres s #%d (%s): unexpected error: %v", i,

--- a/internal_test.go
+++ b/internal_test.go
@@ -12,18 +12,11 @@ interface. The functions are only exported while the tests are being run.
 package ltcutil
 
 import (
-	"github.com/Roasbeef/ltcutil/bech32"
 	"github.com/ltcsuite/ltcd/btcec"
 	"github.com/ltcsuite/ltcutil/base58"
+	"github.com/ltcsuite/ltcutil/bech32"
 	"golang.org/x/crypto/ripemd160"
 )
-
-// SetBlockBytes sets the internal serialized block byte buffer to the passed
-// buffer.  It is used to inject errors and is only available to the test
-// package.
-func (b *Block) SetBlockBytes(buf []byte) {
-	b.serializedBlock = buf
-}
 
 // TstAppDataDir makes the internal appDataDir function available to the test
 // package.

--- a/internal_test.go
+++ b/internal_test.go
@@ -18,6 +18,13 @@ import (
 	"golang.org/x/crypto/ripemd160"
 )
 
+// SetBlockBytes sets the internal serialized block byte buffer to the passed
+// buffer.  It is used to inject errors and is only available to the test
+// package.
+func (b *Block) SetBlockBytes(buf []byte) {
+	b.serializedBlock = buf
+}
+
 // TstAppDataDir makes the internal appDataDir function available to the test
 // package.
 func TstAppDataDir(goos, appName string, roaming bool) string {

--- a/wif_test.go
+++ b/wif_test.go
@@ -29,7 +29,7 @@ func TestEncodeDecodeWIF(t *testing.T) {
 	if err != nil {
 		t.Fatal(err)
 	}
-	wif2, err := NewWIF(priv2, &chaincfg.TestNet3Params, true)
+	wif2, err := NewWIF(priv2, &chaincfg.TestNet4Params, true)
 	if err != nil {
 		t.Fatal(err)
 	}


### PR DESCRIPTION
Fixed naming and pathing errors in order to be able to run all tests properly.

Still, 4 tests are failing, due to expected test BTC values, when running with LTC params:
--- FAIL: TestAddresses
--- FAIL: TestEncodeDecodeWIF
--- FAIL: TestUseBlockHash 
--- FAIL: Example_defaultWalletLayout

Once I am able to understand correctly which values are expected, I would provide a follow-up PR.